### PR TITLE
archiving docs, check out Bedrock Wiki

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,7 @@
+# Public Archive
+
+Documentation from this ScriptAPI Repository will not be updated. Check out [Bedrock Wiki](https://wiki.bedrock.dev/) and [Microsoft Learn](https://learn.microsoft.com/en-us/minecraft/creator/scriptapi/) for up-to-date infomation.
+
 # Documentation
 
 Some example scripts and explaination of using the modules


### PR DESCRIPTION
Script API documentation is moving to Bedrock Wiki. [Bedrock-OSS/bedrock-wiki#583](https://github.com/Bedrock-OSS/bedrock-wiki/pull/583)

We rewrite the scripting articles in bedrock wiki, check it out (https://wiki.bedrock.dev/scripting/starting-scripts)