### PR TITLE
Better forceShow

### DIFF
--- a/scripts/force-show/index.js
+++ b/scripts/force-show/index.js
@@ -3,7 +3,7 @@
 //         Worldwidebrine#9037 <Bedrock Add-Ons>
 // Project: https://github.com/JaylyDev/ScriptAPI
 
-import { Player, system } from "@minecraft/server";
+import { Player, system, GameMode } from "@minecraft/server";
 import { ActionFormData, MessageFormData, ModalFormData } from "@minecraft/server-ui";
 
 /**
@@ -14,12 +14,24 @@ import { ActionFormData, MessageFormData, ModalFormData } from "@minecraft/serve
  * @returns {Promise<Awaited<ReturnType<Form["show"]>>>}
  */
 export async function forceShow(player, form, timeout = Infinity) {
-    const startTick = system.currentTick;
-    while ((system.currentTick - startTick) < timeout) {
-        const response = await /** @type {ReturnType<Form["show"]>} */(form.show(player));
-        if (response.cancelationReason !== "userBusy") {
-            return response;
-        }
-    };
-    throw new Error(`Timed out after ${timeout} ticks`);
+	const startTick = system.currentTick;
+	while ((system.currentTick - startTick) < timeout) {
+		if (!!player.dimension.getPlayers({
+			location: player.location,
+			maxDistance: 1,
+			gameMode: GameMode['survival'],
+		}).find(p => p.id === player.id) || !!player.dimension.getPlayers({
+			location: player.location,
+			maxDistance: 1,
+			gameMode: GameMode['adventure'],
+		}).find(p => p.id === player.id)
+		) {
+			player.dimension.spawnEntity('minecraft:snowball', player.location);
+		}
+		const response = await /** @type {ReturnType<Form["show"]>} */(form.show(player));
+		if (response.cancelationReason !== "userBusy") {
+			return response;
+		}
+	};
+	throw new Error(`Timed out after ${timeout} ticks`);
 };


### PR DESCRIPTION
Now tries to close the player's UI by spawning a snowball at their location if the player is in survival or adventure to hit the player.

Known Issues:
This approach won't work if the player opened the chat UI by pressing the / key on their keyboard for some reason. Apart from that it should work

