### PR TITLE
Update jaylydb index.ts to fix set not updating the value properly

### DIFF
--- a/scripts/jaylydb/index.ts
+++ b/scripts/jaylydb/index.ts
@@ -231,6 +231,8 @@ class JaylyDB implements Map<string, string | number | boolean> {
     if (encoded.length > 32767) throw new RangeError("JaylyDB::set only accepts a string value less than 32767 characters.");
 
     // push change to disk
+    const participant = this.localState.get(key);
+    if (participant) this.objective.removeParticipant(participant.identity);
     this.objective.setScore(encoded, 0);
     const data = {
       encoded_value: encoded,


### PR DESCRIPTION
The set will now properly update the key in the database by removing the old value from the key if the key already exists in the database. Previously the set was not deleting the old value from a key in the scoreboard, instead it was adding a new key with a different value to the scoreboard.